### PR TITLE
Handle new top-level domains

### DIFF
--- a/src/VerifyEmailAddress.py
+++ b/src/VerifyEmailAddress.py
@@ -6,7 +6,7 @@ import dns.resolver
 fromAddress = 'corn@bt.com'
 
 # Simple Regex for syntax checking
-regex = '^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$'
+regex = '^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,})$'
 
 # Email address to verify
 inputAddress = input('Please enter the emailAddress to verify:')


### PR DESCRIPTION
Top-level domains are not limited to 4 characters anymore. For instance, see this huge list of long top-level domains there: https://www.ovh.co.uk/domains/. You can also look at my personal email address (@erine.email) used on GitHub that does not match the proposed regex.